### PR TITLE
Refactor: moving functions

### DIFF
--- a/sim/classes/experiment.py
+++ b/sim/classes/experiment.py
@@ -16,6 +16,9 @@ import numpy as np
 from multipledispatch import dispatch
 from swiplserver import *
 
+from .utils.affinity_utils import get_anti_affinity
+from .utils.prolog_parse_utils import parse_output
+
 from .flow import Flow
 from .infrastructure import Infrastructure
 
@@ -244,81 +247,3 @@ class Experiment:
                 ),
             }
         )
-
-
-def get_anti_affinity(flow_ids):
-
-    N = len(flow_ids)
-    PAIRS = int(math.log2(N))
-
-    all_pairs = list(combinations(flow_ids, 2))
-
-    random.shuffle(all_pairs)
-
-    selected_pairs = all_pairs[:PAIRS]
-
-    anti_affinity = defaultdict(list)
-
-    for f1, f2 in selected_pairs:
-        anti_affinity[f1].append(f2)
-        anti_affinity[f2].append(f1)
-
-    return anti_affinity
-
-
-def parse_prolog(query):
-    if is_prolog_functor(query):
-        if prolog_name(query) != ",":
-            ans = (prolog_name(query), parse_prolog(prolog_args(query)))
-        else:
-            ans = tuple(parse_prolog(prolog_args(query)))
-    elif is_prolog_list(query):
-        ans = [parse_prolog(v) for v in query]
-    elif is_prolog_atom(query):
-        ans = query
-    elif isinstance(query, dict):
-        ans = {k: parse_prolog(v) for k, v in query.items()}
-    else:
-        ans = query
-    return ans
-
-
-def parse_paths(paths):
-    return {
-        (flow, pid): {
-            "path": path,
-            "reliability": reliability,
-            "budgets": budgets,
-            "delay": delay,
-        }
-        for (flow, (pid, (path, (reliability, (budgets, delay))))) in paths
-    }
-
-
-def parse_paths_no_reliability(paths):
-    return {
-        (flow, pid): {
-            "path": path,
-            "budgets": budgets,
-            "delay": delay,
-        }
-        for (flow, (pid, (path, (budgets, delay)))) in paths
-    }
-
-
-def parse_allocation(allocation):
-    return {(s, d): bw for (s, (d, bw)) in allocation}
-
-
-def parse_output(out, plain=True):
-    o = parse_prolog(out)
-    return {
-        "Output": (
-            parse_paths_no_reliability(o["Output"])
-            if plain
-            else parse_paths(o["Output"])
-        ),
-        "Allocation": parse_allocation(o["Allocation"]),
-        "Inferences": o["Inferences"],
-        "Time": o["Time"],
-    }

--- a/sim/classes/experiment_cev.py
+++ b/sim/classes/experiment_cev.py
@@ -19,6 +19,8 @@ from swiplserver import *
 from .flow import Flow
 from .infrastructure import Infrastructure
 
+from .utils.affinity_utils import get_anti_affinity
+from .utils.prolog_parse_utils import parse_output
 
 class Experiment:
     def __init__(
@@ -252,78 +254,3 @@ class Experiment:
                 ),
             }
         )
-
-
-def get_anti_affinity(flow_ids, n=1):
-
-    all_pairs = list(combinations(flow_ids, 2))
-
-    random.shuffle(all_pairs)
-
-    selected_pairs = all_pairs[:n]
-
-    anti_affinity = defaultdict(list)
-
-    for f1, f2 in selected_pairs:
-        anti_affinity[f1].append(f2)
-        anti_affinity[f2].append(f1)
-
-    return anti_affinity
-
-
-def parse_prolog(query):
-    if is_prolog_functor(query):
-        if prolog_name(query) != ",":
-            ans = (prolog_name(query), parse_prolog(prolog_args(query)))
-        else:
-            ans = tuple(parse_prolog(prolog_args(query)))
-    elif is_prolog_list(query):
-        ans = [parse_prolog(v) for v in query]
-    elif is_prolog_atom(query):
-        ans = query
-    elif isinstance(query, dict):
-        ans = {k: parse_prolog(v) for k, v in query.items()}
-    else:
-        ans = query
-    return ans
-
-
-def parse_paths(paths):
-    return {
-        (flow, pid): {
-            "path": path,
-            "reliability": reliability,
-            "budgets": budgets,
-            "delay": delay,
-        }
-        for (flow, (pid, (path, (reliability, (budgets, delay))))) in paths
-    }
-
-
-def parse_paths_no_reliability(paths):
-    return {
-        (flow, pid): {
-            "path": path,
-            "budgets": budgets,
-            "delay": delay,
-        }
-        for (flow, (pid, (path, (budgets, delay)))) in paths
-    }
-
-
-def parse_allocation(allocation):
-    return {(s, d): bw for (s, (d, bw)) in allocation}
-
-
-def parse_output(out, plain=True):
-    o = parse_prolog(out)
-    return {
-        "Output": (
-            parse_paths_no_reliability(o["Output"])
-            if plain
-            else parse_paths(o["Output"])
-        ),
-        "Allocation": parse_allocation(o["Allocation"]),
-        "Inferences": o["Inferences"],
-        "Time": o["Time"],
-    }

--- a/sim/classes/utils/affinity_utils.py
+++ b/sim/classes/utils/affinity_utils.py
@@ -1,0 +1,22 @@
+import math, random
+from itertools import combinations
+from collections import defaultdict
+
+def get_anti_affinity(flow_ids):
+
+    N = len(flow_ids)
+    PAIRS = int(math.log2(N))
+
+    all_pairs = list(combinations(flow_ids, 2))
+
+    random.shuffle(all_pairs)
+
+    selected_pairs = all_pairs[:PAIRS]
+
+    anti_affinity = defaultdict(list)
+
+    for f1, f2 in selected_pairs:
+        anti_affinity[f1].append(f2)
+        anti_affinity[f2].append(f1)
+
+    return anti_affinity

--- a/sim/classes/utils/prolog_parse_utils.py
+++ b/sim/classes/utils/prolog_parse_utils.py
@@ -1,0 +1,59 @@
+from collections import defaultdict
+from swiplserver import *
+
+def parse_prolog(query):
+    if is_prolog_functor(query):
+        if prolog_name(query) != ",":
+            ans = (prolog_name(query), parse_prolog(prolog_args(query)))
+        else:
+            ans = tuple(parse_prolog(prolog_args(query)))
+    elif is_prolog_list(query):
+        ans = [parse_prolog(v) for v in query]
+    elif is_prolog_atom(query):
+        ans = query
+    elif isinstance(query, dict):
+        ans = {k: parse_prolog(v) for k, v in query.items()}
+    else:
+        ans = query
+    return ans
+
+
+def parse_paths(paths):
+    return {
+        (flow, pid): {
+            "path": path,
+            "reliability": reliability,
+            "budgets": budgets,
+            "delay": delay,
+        }
+        for (flow, (pid, (path, (reliability, (budgets, delay))))) in paths
+    }
+
+
+def parse_paths_no_reliability(paths):
+    return {
+        (flow, pid): {
+            "path": path,
+            "budgets": budgets,
+            "delay": delay,
+        }
+        for (flow, (pid, (path, (budgets, delay)))) in paths
+    }
+
+
+def parse_allocation(allocation):
+    return {(s, d): bw for (s, (d, bw)) in allocation}
+
+
+def parse_output(out, plain=True):
+    o = parse_prolog(out)
+    return {
+        "Output": (
+            parse_paths_no_reliability(o["Output"])
+            if plain
+            else parse_paths(o["Output"])
+        ),
+        "Allocation": parse_allocation(o["Allocation"]),
+        "Inferences": o["Inferences"],
+        "Time": o["Time"],
+    }


### PR DESCRIPTION
Refactor: remove local get_anti_affinity and parsing function definitions from the original file; update imports to use get_anti_affinity from affinity_utils.py and parse_prolog, parse_paths, parse_paths_no_reliability, and parse_allocation from prolog_parse_utils.py